### PR TITLE
fix: 修复 #45 ，位于option的捕获组没有被替换

### DIFF
--- a/src/commands/shortcut.ts
+++ b/src/commands/shortcut.ts
@@ -63,7 +63,7 @@ export async function apply(ctx: Context, config: Config) {
       ? [
           ...Object.entries(shortcut.options).map(
             ([key, value]) =>
-              `${key.length > 1 ? '--' : '-'}${key} ${escapeArgs([value])}`,
+              `${key.length > 1 ? '--' : '-'}${key} ${escapeArgs([replaceBracketVar(value, res)])}`,
           ),
         ].join(' ')
       : ''


### PR DESCRIPTION
修复 #45 : 构建option时使用replaceBracketVar，将占位符替换为value